### PR TITLE
feat(ui): refresh landing and header styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -55,13 +55,13 @@
   --card-foreground: #0f172a;
   --popover: #ffffff;
   --popover-foreground: #0f172a;
-  --primary: #c19f2e;
+  --primary: #dabf65;
   --primary-foreground: #111111;
   --secondary: #eadaa7;
   --secondary-foreground: #111111;
   --muted: #f9f4e5;
   --muted-foreground: #6b7280;
-  --accent: #dabf65;
+  --accent: #c19f2e;
   --accent-foreground: #111111;
   --destructive: #b91c1c;
   --border: #eadaa7;
@@ -93,13 +93,13 @@
   --card-foreground: #f9f4e5;
   --popover: #111b3a;
   --popover-foreground: #f9f4e5;
-  --primary: #dabf65;
+  --primary: #c19f2e;
   --primary-foreground: #111111;
   --secondary: #1e293b;
   --secondary-foreground: #f9f4e5;
   --muted: #1e293b;
   --muted-foreground: #cbd5e1;
-  --accent: #c19f2e;
+  --accent: #dabf65;
   --accent-foreground: #111111;
   --destructive: #ef4444;
   --border: #334155;
@@ -131,6 +131,13 @@ html {
 @layer base {
   * {
     @apply border-border outline-ring/50;
+  }
+  a,
+  a:hover,
+  a:focus,
+  a:active,
+  a:visited {
+    text-decoration: none !important;
   }
   body {
     @apply bg-background text-foreground;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,10 +7,10 @@ import { PrimaryButton } from '@/components/PrimaryButton';
 
 export default function Page() {
   return (
-    <div className="bg-background text-foreground flex min-h-screen flex-col">
-      <main className="mx-auto flex min-h-[calc(100vh-5rem)] w-full items-center justify-center px-6 text-center">
+    <div className="bg-background text-foreground flex min-h-[calc(100dvh-4rem)] flex-col">
+      <main className="mx-auto flex flex-1 items-center justify-center px-6 text-center">
         <div className="m-10">
-          <h1 className="text-5xl font-bold sm:text-6xl">RS Tandem</h1>
+          <h1 className="text-4xl font-bold sm:text-6xl">JS Interview Trainer</h1>
           <p className="text-muted-foreground mt-6 max-w-2xl text-lg md:text-3xl">
             Learn JavaScript with the help of mini-games and prepare for technical interviews! Practice algorithms,
             problem solving, and core JS concepts in a fun way.

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { LogIn, LogOut, Menu, SquareMenu } from 'lucide-react';
+import { LogIn, LogOut, Menu, User } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
@@ -19,9 +19,9 @@ import { authService } from '@/services/authorization/auth.service';
 import { useAuth } from '@/services/authorization/auth.store';
 import { LocaleDictionary, localeService, useLocale } from '@/services/locale.service';
 
-import { Button } from './ui/button';
-
 const handleLocaleChange = (locale: string) => localeService.setLocale(locale);
+const headerActionButtonClass =
+  'border-primary/40 bg-gradient-to-b from-primary/10 to-accent/10 text-foreground shadow-xs shadow-primary/10 backdrop-blur-sm hover:border-primary/70 hover:from-primary/80 hover:to-accent/70 hover:text-primary-foreground';
 
 export function Header() {
   const { user, isAuthorized, isAuthorizing } = useAuth();
@@ -73,69 +73,76 @@ export function Header() {
     <header
       className={cn('border-border bg-card relative z-25 border-b', isAuthorizing ? 'cursor-wait select-none' : '')}
     >
-      <div className="relative mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-6">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon" disabled={isAuthorizing}>
-              <Menu className="h-5 w-5" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-48">
-            {Object.entries(routePermissions).map(([route, permission]) => {
-              if (!displayRoute(permission, isAuthorized)) return;
-
-              return (
-                <DropdownMenuItem
-                  key={route}
-                  asChild
-                  className={cn('cursor-pointer', pathname === route && 'bg-primary text-white')}
-                >
-                  <Link
-                    href={route}
-                    className="text-primary flex w-full justify-center font-bold capitalize underline-offset-4 hover:underline"
-                  >
-                    {route.slice(1).replaceAll('-', ' ') || 'home'}
-                  </Link>
-                </DropdownMenuItem>
-              );
-            })}
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        <Button
-          variant={'accent'}
-          size={'lg'}
-          disabled={isAuthorizing}
-          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
-        >
-          <h1 className="text-lg">e-learing center</h1>
-        </Button>
-
-        <div className="flex h-fit w-fit items-start justify-end gap-2.5">
+      <div className="mx-auto flex h-16 w-full max-w-6xl items-center px-6">
+        <div className="flex flex-1">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <PrimaryButton disabled={isAuthorizing} onClick={() => !isAuthorized && router.push(routes.SignIn)}>
+              <PrimaryButton variant="outline" size="icon" disabled={isAuthorizing} className={headerActionButtonClass}>
+                <Menu className="h-5 w-5" />
+              </PrimaryButton>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-48 space-y-0.5 p-0.5">
+              {Object.entries(routePermissions).map(([route, permission]) => {
+                if (!displayRoute(permission, isAuthorized)) return;
+
+                return (
+                  <DropdownMenuItem
+                    key={route}
+                    asChild
+                    className={cn('cursor-pointer', pathname === route && 'bg-primary text-white')}
+                  >
+                    <Link
+                      href={route}
+                      className="text-primary flex w-full justify-center font-bold capitalize underline-offset-4 hover:underline"
+                    >
+                      {route.slice(1).replaceAll('-', ' ') || 'home'}
+                    </Link>
+                  </DropdownMenuItem>
+                );
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        <h1
+          className={cn(
+            'text-accent shrink-0 text-lg font-semibold uppercase',
+            pathname === Routes.Home ? 'hidden' : 'hidden md:block'
+          )}
+        >
+          JS Interview Trainer
+        </h1>
+
+        <div className="flex flex-1 items-start justify-end gap-2.5">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <PrimaryButton
+                variant="outline"
+                disabled={isAuthorizing}
+                onClick={() => !isAuthorized && router.push(routes.SignIn)}
+                className={headerActionButtonClass}
+              >
                 {user ? (
                   <>
-                    <SquareMenu></SquareMenu> {user.username}
+                    <User /> {user.username}
                   </>
                 ) : (
                   <>
-                    <LogIn></LogIn> Sign In
+                    <LogIn /> Sign In
                   </>
                 )}
               </PrimaryButton>
             </DropdownMenuTrigger>
 
             {isAuthorized && (
-              <DropdownMenuContent align="start" className="w-48">
+              <DropdownMenuContent align="start" className="w-48 space-y-0.5 p-0.5">
                 <DropdownMenuItem
                   asChild
                   className="focus:color-white cursor-pointer font-bold text-red-900 focus:bg-red-900 focus:text-white"
                   onClick={handleSignOut}
                 >
                   <div>
-                    <LogOut className="text-inherit"></LogOut>
+                    <LogOut className="text-inherit" />
                     Sign Out
                   </div>
                 </DropdownMenuItem>
@@ -145,24 +152,24 @@ export function Header() {
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant={'outline'} size={'xs'} disabled={isAuthorizing}>
+              <PrimaryButton variant="outline" size="icon" disabled={isAuthorizing} className={headerActionButtonClass}>
                 <Image
                   src={`https://flagcdn.com/w20/${currentLocale}.png`}
                   alt="flag"
                   className="menu-flag height-auto width-auto"
-                  width={20}
-                  height={10}
+                  width={24}
+                  height={12}
                 />
-              </Button>
+              </PrimaryButton>
             </DropdownMenuTrigger>
 
-            <DropdownMenuContent>
+            <DropdownMenuContent className="space-y-0.5 p-0.5">
               {Object.entries(LocaleDictionary).map(([locale, info]) => {
                 return (
                   <DropdownMenuItem asChild key={locale} onClick={() => handleLocaleChange(locale)}>
                     <div
                       className={cn(
-                        'text-primary flex w-full justify-start font-bold capitalize underline-offset-4 hover:underline',
+                        'text-primary flex w-full justify-start font-bold capitalize',
                         currentLocale === locale ? 'bg-primary text-white' : ''
                       )}
                     >
@@ -170,8 +177,8 @@ export function Header() {
                         src={`https://flagcdn.com/w20/${locale}.png`}
                         alt="flag"
                         className="menu-flag height-auto width-auto"
-                        width={20}
-                        height={10}
+                        width={24}
+                        height={12}
                       />
 
                       {info.language}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -120,11 +120,14 @@ export function Header() {
                 variant="outline"
                 disabled={isAuthorizing}
                 onClick={() => !isAuthorized && router.push(routes.SignIn)}
-                className={headerActionButtonClass}
+                className={cn(headerActionButtonClass, user && 'max-w-48')}
               >
                 {user ? (
                   <>
-                    <User /> {user.username}
+                    <User />
+                    <span className="max-w-32 truncate" title={user.username}>
+                      {user.username}
+                    </span>
                   </>
                 ) : (
                   <>


### PR DESCRIPTION
### Theme and Global Styles
- Swapped theme tokens for `primary` and `accent` in both light and dark themes
- Removed link underlines globally (including hover/focus/visited states)

### Header Updates
- Replaced center title from button-wrapped text to plain heading
- Updated header title text to **JS Interview Trainer**
- Unified action controls (menu/profile/language) using `PrimaryButton` with `outline` styling
- Replaced user icon from `SquareMenu` to `User`
- Normalized self-closing icon tag usage