### PR TITLE
Feat: update flip card

### DIFF
--- a/components/Hint.tsx
+++ b/components/Hint.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+
+type HintProperties = {
+  children: string;
+};
+
+function HintComponent({ children }: HintProperties) {
+  return (
+    <div className="m-2 flex justify-center">
+      <Popover>
+        <PopoverTrigger asChild>
+          <button type="button" className="text-muted-foreground cursor-pointer text-sm">
+            Hint
+          </button>
+        </PopoverTrigger>
+
+        <PopoverContent side="bottom" className="px-2 py-1">
+          {children}
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+export const Hint = dynamic(() => Promise.resolve(HintComponent), {
+  ssr: false,
+});

--- a/components/library/widget/ui/flip-card/FlipCard.module.css
+++ b/components/library/widget/ui/flip-card/FlipCard.module.css
@@ -7,7 +7,7 @@
 
 .flip-card-inner {
   width: 100%;
-  height: 100%;
+  height: 90%;
   position: relative;
   transform-style: preserve-3d;
   transition: transform 0.6s;

--- a/components/library/widget/ui/flip-card/FlipCard.module.css
+++ b/components/library/widget/ui/flip-card/FlipCard.module.css
@@ -1,13 +1,15 @@
 .flip-card {
   width: 400px;
-  height: 250px;
   perspective: 1000px;
   margin: 40px auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .flip-card-inner {
   width: 100%;
-  height: 90%;
+  height: 250px;
   position: relative;
   transform-style: preserve-3d;
   transition: transform 0.6s;

--- a/components/library/widget/ui/flip-card/FlipCard.tsx
+++ b/components/library/widget/ui/flip-card/FlipCard.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { FlipCardPayload } from '@/components/library/widget/ui/flip-card/type';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 
 import styles from './FlipCard.module.css';
@@ -78,14 +78,14 @@ export default function FlipCard({ questionPayload, onCheck, onNext }: WidgetCom
         Next
       </Button>
       <div className="m-2">
-        <HoverCard>
-          <HoverCardTrigger asChild>
-            <p className="text-muted-foreground cursor-help text-sm">Hint</p>
-          </HoverCardTrigger>
-          <HoverCardContent side="bottom" className="px-2 py-1">
+        <Popover>
+          <PopoverTrigger asChild>
+            <p className="text-muted-foreground cursor-pointer text-sm">Hint</p>
+          </PopoverTrigger>
+          <PopoverContent side="bottom" className="px-2 py-1">
             {TOOLTIP_HINT}
-          </HoverCardContent>
-        </HoverCard>
+          </PopoverContent>
+        </Popover>
       </div>
     </div>
   );

--- a/components/library/widget/ui/flip-card/FlipCard.tsx
+++ b/components/library/widget/ui/flip-card/FlipCard.tsx
@@ -51,7 +51,7 @@ export default function FlipCard({ questionPayload, onCheck, onNext }: WidgetCom
           </CardContent>
         </Card>
         <Card className={styles['flip-card-back']}>
-          <CardContent className="flex h-full flex-col items-center justify-center gap-4 p-6">
+          <CardContent className="flex h-full cursor-default flex-col items-center justify-center gap-4 p-6">
             <div className="text-center text-lg">{questionPayload.definition}</div>
           </CardContent>
         </Card>

--- a/components/library/widget/ui/flip-card/FlipCard.tsx
+++ b/components/library/widget/ui/flip-card/FlipCard.tsx
@@ -49,22 +49,24 @@ export default function FlipCard({ questionPayload, onCheck, onNext }: WidgetCom
           </CardContent>
         </Card>
       </div>
-      <Button
-        className={`${
-          selected === 'true' ? 'bg-correct-answer' : 'bg-correct-answer-muted'
-        } text-primary-foreground hover:bg-correct-answer/90 rounded-lg px-4 py-2 transition-colors`}
-        onClick={(event) => handleSelect('true', event)}
-      >
-        I know this
-      </Button>
-      <Button
-        className={`${
-          selected === 'false' ? 'bg-wrong-answer' : 'bg-wrong-answer-muted'
-        } text-primary-foreground hover:bg-wrong-answer/90 rounded-lg px-4 py-2 transition-colors`}
-        onClick={(event) => handleSelect('false', event)}
-      >
-        I don&apos;t know this
-      </Button>
+      <div className="m-2 flex justify-center gap-1">
+        <Button
+          className={`${
+            selected === 'true' ? 'bg-correct-answer' : 'bg-correct-answer-muted'
+          } text-primary-foreground hover:bg-correct-answer/90 rounded-lg px-4 py-2 transition-colors`}
+          onClick={(event) => handleSelect('true', event)}
+        >
+          I know this
+        </Button>
+        <Button
+          className={`${
+            selected === 'false' ? 'bg-wrong-answer' : 'bg-wrong-answer-muted'
+          } text-primary-foreground hover:bg-wrong-answer/90 rounded-lg px-4 py-2 transition-colors`}
+          onClick={(event) => handleSelect('false', event)}
+        >
+          I don&apos;t know this
+        </Button>
+      </div>
     </div>
   );
 }

--- a/components/library/widget/ui/flip-card/FlipCard.tsx
+++ b/components/library/widget/ui/flip-card/FlipCard.tsx
@@ -18,23 +18,31 @@ export default function FlipCard({ questionPayload, onCheck, onNext }: WidgetCom
   const [selected, setSelected] = useState<string | undefined>();
 
   const handleFlip = () => {
-    setFlipped((previous) => !previous);
+    setFlipped(true);
   };
 
-  const handleSelect = async (value: string, event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleSelect = (value: string, event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
 
-    setSelected(value);
+    if (!isFlipped) {
+      handleFlip();
+    }
 
-    await onCheck(value);
-    onNext();
+    setSelected(value);
+  };
+
+  const handleNext = async () => {
+    if (selected !== undefined) {
+      onNext();
+      await onCheck(selected);
+    }
   };
 
   return (
-    <div className={styles['flip-card']} onClick={handleFlip}>
+    <div className={styles['flip-card']}>
       <div className={cn(styles['flip-card-inner'], isFlipped && styles.flipped)}>
         <Card className={styles['flip-card-front']}>
-          <CardContent className="flex h-full flex-col items-center justify-center gap-4 p-6">
+          <CardContent className="flex h-full cursor-default flex-col items-center justify-center gap-4 p-6">
             <div className="text-center text-lg">{questionPayload.term}</div>
             <div className="text-muted-foreground text-sm">Click on the card to flip</div>
           </CardContent>
@@ -67,6 +75,9 @@ export default function FlipCard({ questionPayload, onCheck, onNext }: WidgetCom
           I don&apos;t know this
         </Button>
       </div>
+      <Button className="m-2 w-4/5" disabled={selected === undefined} onClick={handleNext}>
+        Next
+      </Button>
     </div>
   );
 }

--- a/components/library/widget/ui/flip-card/FlipCard.tsx
+++ b/components/library/widget/ui/flip-card/FlipCard.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { FlipCardPayload } from '@/components/library/widget/ui/flip-card/type';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { cn } from '@/lib/utils';
 
 import styles from './FlipCard.module.css';
@@ -12,6 +13,9 @@ type WidgetComponentProperties = {
   onCheck: (answer: string) => Promise<boolean | undefined>;
   onNext: () => void;
 };
+
+const TOOLTIP_HINT =
+  'Decide whether you know the answer to reveal it. You can change your resolution after card reveal.';
 
 export default function FlipCard({ questionPayload, onCheck, onNext }: WidgetComponentProperties) {
   const [isFlipped, setFlipped] = useState(false);
@@ -44,16 +48,11 @@ export default function FlipCard({ questionPayload, onCheck, onNext }: WidgetCom
         <Card className={styles['flip-card-front']}>
           <CardContent className="flex h-full cursor-default flex-col items-center justify-center gap-4 p-6">
             <div className="text-center text-lg">{questionPayload.term}</div>
-            <div className="text-muted-foreground text-sm">Click on the card to flip</div>
           </CardContent>
         </Card>
-
         <Card className={styles['flip-card-back']}>
           <CardContent className="flex h-full flex-col items-center justify-center gap-4 p-6">
             <div className="text-center text-lg">{questionPayload.definition}</div>
-            <div className="text-muted-foreground text-center text-sm">
-              Press &quot;I know&quot; if you remember the term, or press &quot;I do not know&quot; if you do not.
-            </div>
           </CardContent>
         </Card>
       </div>
@@ -78,6 +77,16 @@ export default function FlipCard({ questionPayload, onCheck, onNext }: WidgetCom
       <Button className="m-2 w-4/5" disabled={selected === undefined} onClick={handleNext}>
         Next
       </Button>
+      <div className="m-2">
+        <HoverCard>
+          <HoverCardTrigger asChild>
+            <p className="text-muted-foreground cursor-help text-sm">Hint</p>
+          </HoverCardTrigger>
+          <HoverCardContent side="bottom" className="px-2 py-1">
+            {TOOLTIP_HINT}
+          </HoverCardContent>
+        </HoverCard>
+      </div>
     </div>
   );
 }

--- a/components/library/widget/ui/flip-card/FlipCard.tsx
+++ b/components/library/widget/ui/flip-card/FlipCard.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 
+import { Hint } from '@/components/Hint';
 import { FlipCardPayload } from '@/components/library/widget/ui/flip-card/type';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 
 import styles from './FlipCard.module.css';
@@ -77,16 +77,7 @@ export default function FlipCard({ questionPayload, onCheck, onNext }: WidgetCom
       <Button className="m-2 w-4/5" disabled={selected === undefined} onClick={handleNext}>
         Next
       </Button>
-      <div className="m-2">
-        <Popover>
-          <PopoverTrigger asChild>
-            <p className="text-muted-foreground cursor-pointer text-sm">Hint</p>
-          </PopoverTrigger>
-          <PopoverContent side="bottom" className="px-2 py-1">
-            {TOOLTIP_HINT}
-          </PopoverContent>
-        </Popover>
-      </div>
+      <Hint>{TOOLTIP_HINT}</Hint>
     </div>
   );
 }

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Popover as PopoverPrimitive } from 'radix-ui';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="popover-header" className={cn('flex flex-col gap-1 text-sm', className)} {...props} />;
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<'h2'>) {
+  return <div data-slot="popover-title" className={cn('font-medium', className)} {...props} />;
+}
+
+function PopoverDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  return <p data-slot="popover-description" className={cn('text-muted-foreground', className)} {...props} />;
+}
+
+export { Popover, PopoverAnchor, PopoverContent, PopoverDescription, PopoverHeader, PopoverTitle, PopoverTrigger };


### PR DESCRIPTION
Update flip card component after integration into widget runner

**What has been done**
- Updated styles to fix broken UI
- Added next button
- Restricted flip behavior (1 flip only, flip only on clicking a button)
- Moved hint text to a separate component
- Added popover component => mobile-first for hints

**Related Issue**
Closes https://github.com/tosigaeva/rs-tandem/issues/49

![2026-03-23 updated flip card](https://github.com/user-attachments/assets/6de688e6-50e0-40de-9b62-74a80508293d)
