### PR TITLE
Feat: update big o widget

### DIFF
--- a/components/library/widget/ui/big-o-widget/BigOWidget.tsx
+++ b/components/library/widget/ui/big-o-widget/BigOWidget.tsx
@@ -6,6 +6,7 @@ import CodeBlock from '@/components/CodeBlock';
 import { PrimaryButton } from '@/components/PrimaryButton';
 import { Card } from '@/components/ui/card';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 import {
   COMPLEXITIES,
@@ -105,14 +106,14 @@ export function BigOCanvas({ question, codeExample, selectedComplexity, onSelect
       <Card className="w-full max-w-md cursor-default p-4">
         <h2>{question}</h2>
         <CodeBlock code={codeExample} />
-        <HoverCard>
-          <HoverCardTrigger asChild>
-            <p className="text-muted-foreground cursor-help text-sm">Hint</p>
-          </HoverCardTrigger>
-          <HoverCardContent side="bottom" className="w-fit px-2 py-1">
+        <Popover>
+          <PopoverTrigger asChild>
+            <button className="text-muted-foreground cursor-pointer text-sm">Hint</button>
+          </PopoverTrigger>
+          <PopoverContent side="bottom" className="w-fit px-2 py-1">
             {TOOLTIP_HINT}
-          </HoverCardContent>
-        </HoverCard>
+          </PopoverContent>
+        </Popover>
       </Card>
       <Card className="w-full max-w-md cursor-default p-4">
         <p>Selected: {selectedName}</p>

--- a/components/library/widget/ui/big-o-widget/BigOWidget.tsx
+++ b/components/library/widget/ui/big-o-widget/BigOWidget.tsx
@@ -106,7 +106,6 @@ export function BigOCanvas({ question, codeExample, selectedComplexity, onSelect
       <Card className="w-full max-w-md cursor-default p-4">
         <h2>{question}</h2>
         <CodeBlock code={codeExample} />
-        <Hint>{TOOLTIP_HINT}</Hint>
       </Card>
       <Card className="w-full max-w-md cursor-default p-4">
         <p>Selected: {selectedName}</p>
@@ -114,6 +113,7 @@ export function BigOCanvas({ question, codeExample, selectedComplexity, onSelect
       <PrimaryButton disabled={selectedName === ''} onClick={onSubmit}>
         Check Answer
       </PrimaryButton>
+      <Hint>{TOOLTIP_HINT}</Hint>
     </div>
   );
 }

--- a/components/library/widget/ui/big-o-widget/BigOWidget.tsx
+++ b/components/library/widget/ui/big-o-widget/BigOWidget.tsx
@@ -19,7 +19,15 @@ import {
 } from './canvas.helpers';
 import { BigOCanvasProperties } from './type';
 
-export function BigOCanvas({ question, codeExample, selectedComplexity, onSelect, onSubmit }: BigOCanvasProperties) {
+export function BigOCanvas({
+  question,
+  codeExample,
+  selectedComplexity,
+  onSelect,
+  onSubmit,
+  isCorrect,
+  isSubmitted,
+}: BigOCanvasProperties) {
   const width = 400;
   const height = 300;
   const canvasReference = useRef<HTMLCanvasElement>(null);
@@ -28,6 +36,7 @@ export function BigOCanvas({ question, codeExample, selectedComplexity, onSelect
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
 
   const handleClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    if (isSubmitted === true) return;
     const canvas = canvasReference.current;
     if (!canvas) return;
     const rect = canvas.getBoundingClientRect();
@@ -43,6 +52,7 @@ export function BigOCanvas({ question, codeExample, selectedComplexity, onSelect
   };
 
   const handleMouseMove = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    if (isSubmitted === true) return;
     const canvas = canvasReference.current;
     if (!canvas) return;
     const rect = canvas.getBoundingClientRect();
@@ -67,8 +77,8 @@ export function BigOCanvas({ question, codeExample, selectedComplexity, onSelect
     context.clearRect(0, 0, width, height);
 
     drawAxes(context, width, height, PADDING);
-    drawComplexityCurves(context, width, height, selectedLine);
-  }, [width, height, selectedLine]);
+    drawComplexityCurves(context, width, height, selectedLine, isCorrect, isSubmitted);
+  }, [width, height, selectedLine, isCorrect, isSubmitted]);
 
   const selectedName =
     selectedComplexity ?? (selectedLine === undefined ? '' : (COMPLEXITIES[selectedLine]?.name ?? ''));
@@ -111,7 +121,7 @@ export function BigOCanvas({ question, codeExample, selectedComplexity, onSelect
         <p>Selected: {selectedName}</p>
       </Card>
       <PrimaryButton disabled={selectedName === ''} onClick={onSubmit}>
-        Check Answer
+        {isSubmitted === true ? 'Next' : 'Check Answer'}
       </PrimaryButton>
       <Hint>{TOOLTIP_HINT}</Hint>
     </div>

--- a/components/library/widget/ui/big-o-widget/BigOWidget.tsx
+++ b/components/library/widget/ui/big-o-widget/BigOWidget.tsx
@@ -3,10 +3,10 @@
 import { useEffect, useRef, useState } from 'react';
 
 import CodeBlock from '@/components/CodeBlock';
+import { Hint } from '@/components/Hint';
 import { PrimaryButton } from '@/components/PrimaryButton';
 import { Card } from '@/components/ui/card';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 import {
   COMPLEXITIES,
@@ -106,14 +106,7 @@ export function BigOCanvas({ question, codeExample, selectedComplexity, onSelect
       <Card className="w-full max-w-md cursor-default p-4">
         <h2>{question}</h2>
         <CodeBlock code={codeExample} />
-        <Popover>
-          <PopoverTrigger asChild>
-            <button className="text-muted-foreground cursor-pointer text-sm">Hint</button>
-          </PopoverTrigger>
-          <PopoverContent side="bottom" className="w-fit px-2 py-1">
-            {TOOLTIP_HINT}
-          </PopoverContent>
-        </Popover>
+        <Hint>{TOOLTIP_HINT}</Hint>
       </Card>
       <Card className="w-full max-w-md cursor-default p-4">
         <p>Selected: {selectedName}</p>

--- a/components/library/widget/ui/big-o-widget/DefaultComponent.tsx
+++ b/components/library/widget/ui/big-o-widget/DefaultComponent.tsx
@@ -13,14 +13,21 @@ type WidgetComponentProperties = {
 
 export default function DefaultComponent({ questionPayload, onCheck, onNext }: WidgetComponentProperties) {
   const [selectedComplexity, setSelectedComplexity] = useState<string>('');
+  const [isCorrect, setIsCorrect] = useState<boolean | undefined>();
+  const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
 
   const handleSelect = (complexity: string) => {
     setSelectedComplexity(complexity);
   };
 
   const handleSubmit = async () => {
-    await onCheck(selectedComplexity);
-    onNext();
+    if (isSubmitted) {
+      onNext();
+    } else {
+      const result = await onCheck(selectedComplexity);
+      setIsCorrect(result);
+      setIsSubmitted(true);
+    }
   };
 
   return (
@@ -30,6 +37,8 @@ export default function DefaultComponent({ questionPayload, onCheck, onNext }: W
       selectedComplexity={selectedComplexity}
       onSelect={handleSelect}
       onSubmit={handleSubmit}
+      isCorrect={isCorrect}
+      isSubmitted={isSubmitted}
     />
   );
 }

--- a/components/library/widget/ui/big-o-widget/canvas.helpers.ts
+++ b/components/library/widget/ui/big-o-widget/canvas.helpers.ts
@@ -11,6 +11,24 @@ export const COMPLEXITIES: Complexity[] = [
   { name: 'O(n^2)', func: (n: number) => n * n },
 ];
 
+export function getCurveColors() {
+  if (globalThis.window === undefined) {
+    return {
+      correctCurve: '#8bb864',
+      wrongCurve: '#b13f3f',
+      selectedCurve: '#dabf65',
+    };
+  }
+
+  const styles = getComputedStyle(document.documentElement);
+
+  return {
+    correctCurve: styles.getPropertyValue('--correct-answer').trim(),
+    wrongCurve: styles.getPropertyValue('--wrong-answer').trim(),
+    selectedCurve: styles.getPropertyValue('--primary').trim(),
+  };
+}
+
 export function getClosestComplexity(
   mouseX: number,
   mouseY: number,
@@ -49,6 +67,7 @@ export function drawComplexityCurves(
   isCorrect?: boolean,
   isSubmitted?: boolean
 ) {
+  const curveColors = getCurveColors();
   const minX = 1;
   const maxX = 5;
   const maxY = Math.max(...COMPLEXITIES.map((c) => c.func(maxX) - c.func(minX)));
@@ -71,9 +90,9 @@ export function drawComplexityCurves(
     if (selectedLineIndex === index) {
       lineWidth = 2;
       if (isSubmitted === true) {
-        strokeColor = isCorrect === true ? '#22c55e' : '#ef4444';
+        strokeColor = isCorrect === true ? curveColors.correctCurve : curveColors.wrongCurve;
       } else {
-        strokeColor = '#3b82f6';
+        strokeColor = curveColors.selectedCurve;
       }
     }
 

--- a/components/library/widget/ui/big-o-widget/canvas.helpers.ts
+++ b/components/library/widget/ui/big-o-widget/canvas.helpers.ts
@@ -45,7 +45,9 @@ export function drawComplexityCurves(
   context: CanvasRenderingContext2D,
   width: number,
   height: number,
-  selectedLineIndex?: number
+  selectedLineIndex?: number,
+  isCorrect?: boolean,
+  isSubmitted?: boolean
 ) {
   const minX = 1;
   const maxX = 5;
@@ -63,8 +65,20 @@ export function drawComplexityCurves(
       else context.lineTo(canvasX, canvasY);
     }
 
-    context.strokeStyle = selectedLineIndex === index ? '#FF0000' : '#000';
-    context.lineWidth = selectedLineIndex === index ? 2 : 1;
+    let strokeColor = '#000';
+    let lineWidth = 1;
+
+    if (selectedLineIndex === index) {
+      lineWidth = 2;
+      if (isSubmitted === true) {
+        strokeColor = isCorrect === true ? '#22c55e' : '#ef4444';
+      } else {
+        strokeColor = '#3b82f6';
+      }
+    }
+
+    context.strokeStyle = strokeColor;
+    context.lineWidth = lineWidth;
     context.stroke();
   });
 }

--- a/components/library/widget/ui/big-o-widget/type.ts
+++ b/components/library/widget/ui/big-o-widget/type.ts
@@ -21,4 +21,6 @@ export type BigOCanvasProperties = {
   selectedComplexity?: string;
   onSelect: (complexity: string) => void;
   onSubmit: () => void;
+  isCorrect?: boolean;
+  isSubmitted?: boolean;
 };


### PR DESCRIPTION
Updated Big O widget

**What has been done**
- Integrated Hint component (note: I keep HoverCard inside canvas as it's a better solution for a tooltip with dynamic positioning according to my research)
- Added dynamic state of button depending on submit status ('Check answer' or 'Next')
- Added UI response inside canvas to reflect response validation status (color update)
- Integrated re-use of color for canvas directly from tailwind

**Related Issue**
Closes https://github.com/tosigaeva/rs-tandem/issues/88

![2026-03-24 updated 1](https://github.com/user-attachments/assets/90a449b4-906f-4d20-907e-0c39a03e6da2)
![2026-03-24 updated 2](https://github.com/user-attachments/assets/67799329-1e8c-4b9e-961f-3c92ba181190)
