### PR TITLE
feat: localize daily activity tooltip plurals and date formatting

### DIFF
--- a/components/dashboard/activity/ActivityDayCell.tsx
+++ b/components/dashboard/activity/ActivityDayCell.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
+import { useTranslation } from '@/hooks/use-translation';
 import { cn } from '@/lib/utils';
+import { LanguageCode } from '@/services/locale/locale.service';
+import type { MessageKey } from '@/services/locale/messages';
+import { selectPluralCategory } from '@/services/locale/plural';
 
 import { activityLevelColorMap } from './activity.constants';
 import { ActivityCell } from './activity.types';
@@ -11,30 +15,55 @@ type ActivityDayCellProperties = {
   day: ActivityCell;
 };
 
-function getDayLabel(day: ActivityCell): string {
-  const formattedDate = formatDateLabel(day.date);
+function formatMessage(template: string, values: Record<string, string | number>): string {
+  return template.replaceAll(/\{(\w+)\}/g, (match, token) => String(values[token] ?? match));
+}
 
-  if (day.count === 0) {
-    return `No activity on ${formattedDate}`;
+function getAnswerLabelKey(count: number, languageCode: LanguageCode): MessageKey {
+  const category = selectPluralCategory(count, languageCode);
+
+  if (category === 'one') {
+    return 'dashboard.activity.day.answers.one';
   }
 
-  return `${day.count} answers on ${formattedDate}`;
+  if (category === 'few') {
+    return 'dashboard.activity.day.answers.few';
+  }
+
+  if (category === 'many') {
+    return 'dashboard.activity.day.answers.many';
+  }
+
+  return 'dashboard.activity.day.answers.other';
+}
+
+function getDayLabel(day: ActivityCell, languageCode: LanguageCode, t: (key: MessageKey) => string): string {
+  const formattedDate = formatDateLabel(day.date, languageCode);
+
+  if (day.count === 0) {
+    return formatMessage(t('dashboard.activity.day.no'), { date: formattedDate });
+  }
+
+  return formatMessage(t(getAnswerLabelKey(day.count, languageCode)), { count: day.count, date: formattedDate });
 }
 
 export function ActivityDayCell({ day }: ActivityDayCellProperties) {
+  const { t, languageCode } = useTranslation();
+  const label = getDayLabel(day, languageCode, t);
+
   return (
     <HoverCard openDelay={80} closeDelay={40}>
       <HoverCardTrigger asChild>
         <button
           type="button"
-          aria-label={getDayLabel(day)}
+          aria-label={label}
           className={cn(
             'focus-visible:ring-ring h-3 w-3 rounded-full transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:outline-none'
           )}
           style={{ backgroundColor: activityLevelColorMap[day.level] }}
         />
       </HoverCardTrigger>
-      <HoverCardContent className="w-fit px-3 py-2 text-xs">{getDayLabel(day)}</HoverCardContent>
+      <HoverCardContent className="w-fit px-3 py-2 text-xs">{label}</HoverCardContent>
     </HoverCard>
   );
 }

--- a/components/dashboard/activity/ActivityHeatmap.tsx
+++ b/components/dashboard/activity/ActivityHeatmap.tsx
@@ -2,6 +2,8 @@
 
 import { eachDayOfInterval, endOfMonth, getISODay, startOfMonth, subMonths } from 'date-fns';
 
+import { useLocale } from '@/services/locale/locale.service';
+
 import { ActivityCell, ActivityDay } from './activity.types';
 import { getActivityLevel } from './activity.utilities';
 import { formatMonthLabel, getDateKey, parseDateKey } from './activity-date.utilities';
@@ -65,6 +67,7 @@ function buildMonthCells(monthDate: Date, countsByDate: Map<string, number>): Ca
 }
 
 export function ActivityHeatmap({ days, monthCount = 3 }: ActivityHeatmapProperties) {
+  const { languageCode } = useLocale();
   const countsByDate = getCountsByDate(days);
   const currentMonth = startOfMonth(new Date());
   const months = Array.from({ length: monthCount }, (_, index) => subMonths(currentMonth, monthCount - index - 1));
@@ -74,7 +77,7 @@ export function ActivityHeatmap({ days, monthCount = 3 }: ActivityHeatmapPropert
       <div className="inline-flex w-max items-start gap-2.5">
         {months.map((monthDate) => {
           const monthCells = buildMonthCells(monthDate, countsByDate);
-          const monthLabel = formatMonthLabel(getDateKey(monthDate));
+          const monthLabel = formatMonthLabel(getDateKey(monthDate), languageCode);
 
           return (
             <article key={getDateKey(monthDate)} className="space-y-3">

--- a/components/dashboard/activity/activity-date.utilities.ts
+++ b/components/dashboard/activity/activity-date.utilities.ts
@@ -1,7 +1,10 @@
 import { eachDayOfInterval, format, parseISO, startOfDay, subDays } from 'date-fns';
 
+import { LanguageCode } from '@/services/locale/locale.service';
+import { getDateFnsLocale } from '@/services/locale/locale-format';
+
 const dateKeyFormat = 'yyyy-MM-dd';
-const dateLabelFormat = 'MMM d, yyyy';
+const dateLabelFormat = 'PPP';
 const monthLabelFormat = 'MMM';
 
 export function getDateKey(date: Date): string {
@@ -18,24 +21,24 @@ export function parseDateKey(date: string): Date | undefined {
   return parsedDate;
 }
 
-export function formatDateLabel(date: string): string {
+export function formatDateLabel(date: string, languageCode: LanguageCode = LanguageCode.en): string {
   const parsedDate = parseDateKey(date);
 
   if (parsedDate === undefined) {
     return date;
   }
 
-  return format(parsedDate, dateLabelFormat);
+  return format(parsedDate, dateLabelFormat, { locale: getDateFnsLocale(languageCode) });
 }
 
-export function formatMonthLabel(date: string): string {
+export function formatMonthLabel(date: string, languageCode: LanguageCode = LanguageCode.en): string {
   const parsedDate = parseDateKey(date);
 
   if (parsedDate === undefined) {
     return date;
   }
 
-  return format(parsedDate, monthLabelFormat);
+  return format(parsedDate, monthLabelFormat, { locale: getDateFnsLocale(languageCode) });
 }
 
 export function normalizeDate(date: Date): Date {

--- a/components/dashboard/activity/activity.constants.ts
+++ b/components/dashboard/activity/activity.constants.ts
@@ -7,9 +7,11 @@ export const activityLevelColorMap: Record<ActivityLevel, string> = {
   high: 'var(--heatmap-high)',
 };
 
+export type ActivityLegendLevel = Exclude<ActivityLevel, 'medium'>;
+
 type ActivityLegendItem = {
   label: string;
-  level: ActivityLevel;
+  level: ActivityLegendLevel;
 };
 
 export const activityLegendItems: ReadonlyArray<ActivityLegendItem> = [

--- a/hooks/use-translation.tsx
+++ b/hooks/use-translation.tsx
@@ -17,5 +17,5 @@ export function useTranslation() {
     return localRecord[languageCode] ?? localRecord[LanguageCode.en] ?? '';
   };
 
-  return { t, translate };
+  return { t, translate, languageCode };
 }

--- a/services/locale/locale-format.ts
+++ b/services/locale/locale-format.ts
@@ -1,0 +1,34 @@
+import type { Locale as DateFnsLocale } from 'date-fns';
+import { be, enUS, ru } from 'date-fns/locale';
+
+import { LanguageCode } from './locale.service';
+
+type IntlLocale = 'en' | 'ru' | 'be';
+
+type LocaleFormatConfig = {
+  intlLocale: IntlLocale;
+  dateFnsLocale: DateFnsLocale;
+};
+
+const localeFormatMap: Record<LanguageCode, LocaleFormatConfig> = {
+  [LanguageCode.en]: {
+    intlLocale: 'en',
+    dateFnsLocale: enUS,
+  },
+  [LanguageCode.ru]: {
+    intlLocale: 'ru',
+    dateFnsLocale: ru,
+  },
+  [LanguageCode.by]: {
+    intlLocale: 'be',
+    dateFnsLocale: be,
+  },
+};
+
+export function getIntlLocale(languageCode: LanguageCode): IntlLocale {
+  return localeFormatMap[languageCode].intlLocale;
+}
+
+export function getDateFnsLocale(languageCode: LanguageCode): DateFnsLocale {
+  return localeFormatMap[languageCode].dateFnsLocale;
+}

--- a/services/locale/messages.ts
+++ b/services/locale/messages.ts
@@ -56,6 +56,31 @@ export const AppMessages = {
     [LanguageCode.ru]: 'Пока нет активности. Сначала решите несколько вопросов.',
     [LanguageCode.by]: 'Пакуль няма актыўнасці. Спачатку вырашыце некалькі пытанняў.',
   },
+  'dashboard.activity.day.no': {
+    [LanguageCode.en]: 'No activity on {date}',
+    [LanguageCode.ru]: 'Нет активности: {date}',
+    [LanguageCode.by]: 'Няма актыўнасці: {date}',
+  },
+  'dashboard.activity.day.answers.one': {
+    [LanguageCode.en]: '{count} answer on {date}',
+    [LanguageCode.ru]: '{count} ответ: {date}',
+    [LanguageCode.by]: '{count} адказ: {date}',
+  },
+  'dashboard.activity.day.answers.few': {
+    [LanguageCode.en]: '{count} answers on {date}',
+    [LanguageCode.ru]: '{count} ответа: {date}',
+    [LanguageCode.by]: '{count} адказы: {date}',
+  },
+  'dashboard.activity.day.answers.many': {
+    [LanguageCode.en]: '{count} answers on {date}',
+    [LanguageCode.ru]: '{count} ответов: {date}',
+    [LanguageCode.by]: '{count} адказаў: {date}',
+  },
+  'dashboard.activity.day.answers.other': {
+    [LanguageCode.en]: '{count} answers on {date}',
+    [LanguageCode.ru]: '{count} ответа: {date}',
+    [LanguageCode.by]: '{count} адказа: {date}',
+  },
 
   /// results
   'results.perfect.title': {

--- a/services/locale/plural.ts
+++ b/services/locale/plural.ts
@@ -1,0 +1,22 @@
+import { LanguageCode } from './locale.service';
+import { getIntlLocale } from './locale-format';
+
+const pluralRulesCache = new Map<string, Intl.PluralRules>();
+
+function getPluralRules(languageCode: LanguageCode): Intl.PluralRules {
+  const locale = getIntlLocale(languageCode);
+  const cachedRules = pluralRulesCache.get(locale);
+
+  if (cachedRules != undefined) {
+    return cachedRules;
+  }
+
+  const rules = new Intl.PluralRules(locale);
+
+  pluralRulesCache.set(locale, rules);
+  return rules;
+}
+
+export function selectPluralCategory(count: number, languageCode: LanguageCode): Intl.LDMLPluralRule {
+  return getPluralRules(languageCode).select(count);
+}


### PR DESCRIPTION
- Added i18n support for DailyActivity day tooltips
- Implemented plural category selection via `Intl.PluralRules` in a shared helper (`services/locale/plural.ts`)
- Extended `useTranslation()` to also expose languageCode and used it in ActivityDayCell to avoid duplicate locale store subscription there. Notes: same can be done in `TopicCard`, it was intentionally left unchanged for this PR